### PR TITLE
Remove the notion of a "Not task" tile

### DIFF
--- a/Database/Schema.sql
+++ b/Database/Schema.sql
@@ -13,8 +13,7 @@
  CREATE TABLE Task (
     RowID int PRIMARY KEY AUTO_INCREMENT,
     Name varchar(50) NOT NULL,
-    Difficulty tinyint NOT NULL,
-    Number int NOT NULL
+    Difficulty tinyint NOT NULL
 );
 
  CREATE TABLE Restriction (
@@ -39,10 +38,13 @@ CREATE TABLE TaskRestriction (
 	TeamID int NOT NULL,
 	TaskID int NOT NULL,
     Verified tinyint NOT NULL,
+    BoardIndex int NOT NULL,
     FOREIGN KEY (TeamID) REFERENCES Team(RowID),
     FOREIGN KEY (TaskID) REFERENCES Task(RowID),
 	CONSTRAINT team_task_relationship UNIQUE KEY (TeamID, TaskID),
-	CONSTRAINT task_team_relationship UNIQUE KEY (TaskID, TeamID)
+	CONSTRAINT task_team_relationship UNIQUE KEY (TaskID, TeamID),
+	CONSTRAINT team_boardIndex_relationship UNIQUE KEY (TeamID, BoardIndex),
+	CONSTRAINT boardIndex_team_relationship UNIQUE KEY (BoardIndex, TeamID)
 );
   
  CREATE TABLE Evidence (

--- a/RSBingo-Framework/DAL/DataFactory.cs
+++ b/RSBingo-Framework/DAL/DataFactory.cs
@@ -46,13 +46,6 @@ public static class DataFactory
     public static DiscordGuild Guild => guild;
 
     /// <summary>
-    /// Gets a list of all "No task" <see cref="BingoTask"/>s that are not being used
-    /// in a given team's tiles.<br/>
-    /// This should be kept up to date as tiles' tasks change.
-    /// </summary>
-    public static Dictionary<int, List<BingoTask>> AvailableNoTasks { get; } = new();
-
-    /// <summary>
     /// Setup the data factory ready to process requests for data connections.
     /// </summary>
     /// <param name="asMockDB">Flag if this factory should act as a MockDB.</param>

--- a/RSBingo-Framework/DAL/RSBingoContext.cs
+++ b/RSBingo-Framework/DAL/RSBingoContext.cs
@@ -171,11 +171,16 @@ public partial class RSBingoContext : DbContext
             entity.HasIndex(e => new { e.TaskId, e.TeamId }, "task_team_relationship")
                 .IsUnique();
 
+            entity.HasIndex(e => new { e.BoardIndex, e.TeamId }, "BoardIndex_team_relationship")
+                .IsUnique();
+
             entity.Property(e => e.RowId).HasColumnName("RowID");
 
             entity.Property(e => e.TaskId).HasColumnName("TaskID");
 
             entity.Property(e => e.TeamId).HasColumnName("TeamID");
+
+            entity.Property(e => e.BoardIndex).HasColumnName("BoardIndex");
 
             entity.HasOne(d => d.Task)
                 .WithMany(p => p.Tiles)

--- a/RSBingo-Framework/Interfaces/IRepository/IBingoTaskRepository.cs
+++ b/RSBingo-Framework/Interfaces/IRepository/IBingoTaskRepository.cs
@@ -17,8 +17,7 @@ namespace RSBingo_Framework.Interfaces.IRepository
         public IEnumerable<BingoTask> GetByName(string name);
         public IEnumerable<BingoTask> GetByNameAndDifficulty(string name, Difficulty difficulty);
         public BingoTask? GetById(int id);
-        public IEnumerable<BingoTask> GetAllNoTasks();
-        public IEnumerable<BingoTask> GetAllTasks(bool excludingNoTasks = true);
+        public IEnumerable<BingoTask> GetAllTasks();
         public IEnumerable<BingoTask> GetAllWithDifficulty(Difficulty difficulty);
         public void Delete(string name, Difficulty difficulty);
         public void Delete(BingoTask bingoTask);

--- a/RSBingo-Framework/Interfaces/IRepository/ITileRepository.cs
+++ b/RSBingo-Framework/Interfaces/IRepository/ITileRepository.cs
@@ -12,10 +12,10 @@ namespace RSBingo_Framework.Interfaces.IRepository
     /// </summary>
     public interface ITileRepository : IRepository<Tile>
     {
-        public Tile Create(string teamName, int taskId, VerifiedStatus verifiedStatus = VerifiedStatus.No);
-        public Tile Create(string teamName, BingoTask task, VerifiedStatus verifiedStatus = VerifiedStatus.No);
-        public Tile Create(Team team, BingoTask task, VerifiedStatus verifiedStatus = VerifiedStatus.No);
-        public Tile Create(int teamId, int taskId, VerifiedStatus verifiedStatus = VerifiedStatus.No, int? rowId = null);
+        public Tile Create(string teamName, int taskId, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No);
+        public Tile Create(string teamName, BingoTask task, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No);
+        public Tile Create(Team team, BingoTask task, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No);
+        public Tile Create(int teamId, int taskId, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No);
         public Tile? GetById(int id);
         public IEnumerable<Tile> GetByIds(IEnumerable<int> ids);
         public IEnumerable<Tile> GetByTaskId(int id);
@@ -29,12 +29,8 @@ namespace RSBingo_Framework.Interfaces.IRepository
         public IEnumerable<Tile> GetByTasks(IEnumerable<BingoTask> tasks);
         public Tile? GetByTeamAndTaskId(Team team, int taskId);
         public IEnumerable<Tile> GetAllTiles();
-        public void SetToNoTask(Tile tile);
-
-        public void SetToNoTask(IEnumerable<Tile> tiles);
         public void ChangeTask(Tile tile, BingoTask task);
         public void SwapTasks(Tile tile1, Tile tile2);
-
         public void Delete(Tile tile);
         public void DeleteMany(IEnumerable<Tile> tiles);
     }

--- a/RSBingo-Framework/Models/Tile.cs
+++ b/RSBingo-Framework/Models/Tile.cs
@@ -15,6 +15,7 @@ namespace RSBingo_Framework.Models
         public int TeamId { get; set; }
         public int TaskId { get; set; }
         public sbyte Verified { get; set; }
+        public int BoardIndex { get; set; }
 
         public virtual BingoTask Task { get; set; } = null!;
         public virtual Team Team { get; set; } = null!;

--- a/RSBingo-Framework/Records/TeamRecord.cs
+++ b/RSBingo-Framework/Records/TeamRecord.cs
@@ -17,8 +17,5 @@ namespace RSBingo_Framework.Records
 
         public static bool IsBoardVerfied(this Team team) =>
             team.Tiles.FirstOrDefault(t => t.IsNotVerified()) == null;
-
-        public static IEnumerable<Tile> GetNoTaskTiles(this Team team) =>
-            team.Tiles.Where(t => t.Task.Name == BingoTaskRepository.NoTaskName);
     }
 }

--- a/RSBingo-Framework/Records/TileRecord.cs
+++ b/RSBingo-Framework/Records/TileRecord.cs
@@ -30,24 +30,7 @@ namespace RSBingo_Framework.Records
         public static bool IsNotVerified(this Tile tile) =>
             tile.Verified != 1;
 
-        public static void ChangeTask(this Tile tile, BingoTask task)
-        {
-            if (tile.Task.Name == BingoTaskRepository.NoTaskName)
-            {
-                DataFactory.AvailableNoTasks[tile.Team.RowId].Add(tile.Task);
-            }
-
-            if (task.Name == BingoTaskRepository.NoTaskName)
-            {
-                DataFactory.AvailableNoTasks[tile.Team.RowId].Remove(task);
-            }
-
-            tile.TaskId = task.RowId;
-        }
-
-        public static void SetToNoTask(this Tile tile)
-        {
-            ChangeTask(tile, DataFactory.AvailableNoTasks[tile.Team.RowId][0]);
-        }
+        public static void ChangeTask(this Tile tile, BingoTask task) =>
+            tile.Task = task;
     }
 }

--- a/RSBingo-Framework/Repository/BingoTaskRepository.cs
+++ b/RSBingo-Framework/Repository/BingoTaskRepository.cs
@@ -14,8 +14,6 @@ namespace RSBingo_Framework.Repository
     /// </summary>
     public class BingoTaskRepository : RepositoryBase<BingoTask>, IBingoTaskRepository
     {
-        public const string NoTaskName = "No task";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="BingoTaskRepository"/> class.
         /// </summary>
@@ -59,11 +57,8 @@ namespace RSBingo_Framework.Repository
         public BingoTask? GetById(int id) =>
            FirstOrDefault(t => t.RowId == id);
 
-        public IEnumerable<BingoTask> GetAllNoTasks() =>
-            Where(t => t.Name == NoTaskName);
-
-        public IEnumerable<BingoTask> GetAllTasks(bool excludingNoTasks = true) =>
-            Where(t => !excludingNoTasks || t.Name != NoTaskName);
+        public IEnumerable<BingoTask> GetAllTasks() =>
+            GetAll();
 
         public IEnumerable<BingoTask> GetAllWithDifficulty(Difficulty difficulty) =>
             Where(t => t.Difficulty == (sbyte)difficulty).ToList();

--- a/RSBingo-Framework/Repository/TeamRepository.cs
+++ b/RSBingo-Framework/Repository/TeamRepository.cs
@@ -32,16 +32,6 @@ namespace RSBingo_Framework.Repository
                 Name = name,
                 BoardChannelId = boardChannelId,
             });
-            DataWorker.SaveChanges();
-
-            DataFactory.AvailableNoTasks[team.RowId] = new();
-            IEnumerable<BingoTask> tasks = DataWorker.BingoTasks.GetAllNoTasks();
-            foreach (BingoTask task in tasks)
-            {
-                DataFactory.AvailableNoTasks[team.RowId].Add(task);
-                DataWorker.Tiles.Create(team, task);
-            }
-
             return team;
         }
 

--- a/RSBingo-Framework/Repository/TileRepository.cs
+++ b/RSBingo-Framework/Repository/TileRepository.cs
@@ -29,33 +29,33 @@ namespace RSBingo_Framework.Repository
             return Add(new Tile());
         }
 
-        public Tile Create(string teamName, int taskId, VerifiedStatus verifiedStatus = VerifiedStatus.No)
+        public Tile Create(string teamName, int taskId, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No)
         {
             BingoTask? task = DataWorker.BingoTasks.GetById(taskId);
             if (task == null) { throw new NullReferenceException($"Could not find task with id {taskId}."); }
 
-            return Create(teamName, task, verifiedStatus);
+            return Create(teamName, task, boardIndex, verifiedStatus);
         }
 
-        public Tile Create(string teamName, BingoTask task, VerifiedStatus verifiedStatus = VerifiedStatus.No)
+        public Tile Create(string teamName, BingoTask task, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No)
         {
             Team? team = DataWorker.Teams.GetByName(teamName);
             if (team == null) { throw new NullReferenceException($"Could not find team with name {teamName}."); }
 
-            return Create(team, task, verifiedStatus);
+            return Create(team, task, boardIndex, verifiedStatus);
         }
 
-        public Tile Create(Team team, BingoTask task, VerifiedStatus verifiedStatus = VerifiedStatus.No) =>
-            Create(team.RowId, task.RowId, verifiedStatus);
+        public Tile Create(Team team, BingoTask task, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No) =>
+            Create(team.RowId, task.RowId, boardIndex, verifiedStatus);
 
-        public Tile Create(int teamId, int taskId, VerifiedStatus verifiedStatus = VerifiedStatus.No, int? rowId = null)
+        public Tile Create(int teamId, int taskId, int boardIndex, VerifiedStatus verifiedStatus = VerifiedStatus.No)
         {
             return Add(new Tile()
             {
-                RowId = rowId ?? new int(),
                 TeamId = teamId,
                 TaskId = taskId,
-                Verified = (sbyte)verifiedStatus
+                Verified = (sbyte)verifiedStatus,
+                BoardIndex = boardIndex
             });
         }
 
@@ -80,31 +80,21 @@ namespace RSBingo_Framework.Repository
         public IEnumerable<Tile> GetAllTiles() =>
             GetAll();
 
-        public void SetToNoTask(Tile tile)
-        {
-            tile.SetToNoTask();
-        }
-
-        public void SetToNoTask(IEnumerable<Tile> tiles)
-        {
-            foreach (Tile tile in tiles)
-            {
-                SetToNoTask(tile);
-            }
-        }
-
         public void ChangeTask(Tile tile, BingoTask task) =>
             tile.ChangeTask(task);
 
         public void SwapTasks(Tile tile1, Tile tile2)
         {
+            // TODO: JR - fix this
             BingoTask tile1Task = tile1.Task;
-            BingoTask tile2Task = tile2.Task;
-            tile1.SetToNoTask();
-            tile2.SetToNoTask();
-            DataWorker.SaveChanges();
-            tile1.ChangeTask(tile2Task);
-            tile2.ChangeTask(tile1Task);
+            tile1.Task = tile2.Task;
+            tile2.Task = tile1Task;
+            //BingoTask tile2Task = tile2.Task;
+            ////tile1.SetToNoTask();
+            ////tile2.SetToNoTask();
+            ////DataWorker.SaveChanges();
+            //tile1.ChangeTask(tile2Task);
+            //tile2.ChangeTask(tile1Task);
         }
 
         public void Delete(Tile tile) =>

--- a/RSBingoBot/Component interaction handlers/ChangeTileButtonHanlder.cs
+++ b/RSBingoBot/Component interaction handlers/ChangeTileButtonHanlder.cs
@@ -25,6 +25,7 @@ namespace RSBingoBot.Component_interaction_handlers
     public class ChangeTileButtonHanlder : ComponentInteractionHandler
     {
         private const string PageOptionPrefix = "Page ";
+        private const string NoTaskName = "No task";
 
         private string fromTileSelectId = string.Empty;
         private string? fromTileSelectedTileId = null;
@@ -32,7 +33,7 @@ namespace RSBingoBot.Component_interaction_handlers
         private List<DiscordSelectComponentOption> fromTileSelectOptions = new();
 
         private string toTileSelectId = string.Empty;
-        private int toTileSelectedTileId = -1;
+        private int toTaskSelectedTileId = -1;
 
         private int? pageSelected = null;
         private Difficulty difficultySelected;
@@ -80,11 +81,24 @@ namespace RSBingoBot.Component_interaction_handlers
             {
                 // Team will not be null if TeamMustExist == true, which it should be for this instance.
                 fromTileSelectOptions = new();
+                IEnumerable<Tile> tiles = Team!.Tiles.OrderBy(t => t.BoardIndex);
+                int tileIndex = 0;
+                string name;
+                string value;
 
                 for (int i = 0; i < TilesPerRow * TilesPerColumn; i++)
                 {
-                    fromTileSelectOptions.Add(new (Team.Tiles.ElementAt(i).Task.Name,
-                        Team.Tiles.ElementAt(i).RowId.ToString()));
+                    name = NoTaskName;
+                    value = NoTaskName + i.ToString();
+
+                    if (tileIndex < tiles.Count() && tiles.ElementAt(tileIndex).BoardIndex == i)
+                    {
+                        name = tiles.ElementAt(tileIndex).Task.Name;
+                        value = tiles.ElementAt(tileIndex).RowId.ToString();
+                        tileIndex++;
+                    }
+
+                    fromTileSelectOptions.Add(new (name, value));
                 }
             }
             else
@@ -139,7 +153,9 @@ namespace RSBingoBot.Component_interaction_handlers
         private async Task FromTileSelectInteracted(DiscordClient client, ComponentInteractionCreateEventArgs args)
         {
             fromTileSelectedTileId = args.Values[0];
-            fromTileSelectPlaceholder = DataWorker.Tiles.GetById(int.Parse(fromTileSelectedTileId)).Task.Name;
+            fromTileSelectPlaceholder = fromTileSelectedTileId.StartsWith(NoTaskName) ?
+                NoTaskName :
+                DataWorker.Tiles.GetById(int.Parse(fromTileSelectedTileId)).Task.Name;
             await args.Interaction.CreateResponseAsync(InteractionResponseType.DeferredMessageUpdate);
         }
 
@@ -170,7 +186,7 @@ namespace RSBingoBot.Component_interaction_handlers
             }
             else if (selectStage == SelectStage.Task)
             {
-                toTileSelectedTileId = int.Parse(args.Values[0]);
+                toTaskSelectedTileId = int.Parse(args.Values[0]);
             }
         }
 
@@ -211,33 +227,42 @@ namespace RSBingoBot.Component_interaction_handlers
                 await InteractionConcluded();
                 return;
             }
-            else if (fromTileSelectedTileId == null || toTileSelectedTileId == -1)
+            else if (fromTileSelectedTileId == null || toTaskSelectedTileId == -1)
             {
                  editBuilderContent = "Must select a tile to change both from, and to.";
             }
             else
             {
-                BingoTask toTask = DataWorker.BingoTasks.GetById(toTileSelectedTileId);
-                Tile fromTile = DataWorker.Tiles.GetById(int.Parse(fromTileSelectedTileId));
+                // TODO: hook up tile changes with the update handler
+                BingoTask toTask = DataWorker.BingoTasks.GetById(toTaskSelectedTileId);
 
-                if (toSelectOptions.IsTaskOnBoard(toTask.RowId))
+                if (fromTileSelectedTileId.StartsWith(NoTaskName))
                 {
-                    Tile toTile = DataWorker.Tiles.GetByTeamAndTaskId(Team, toTask.RowId);
-
-                    if (toTile == fromTile)
-                    {
-                        editBuilderContent = $"You selected the same tile twice, so nothing happened.";
-                    }
-                    else
-                    {
-                        DataWorker.Tiles.SwapTasks(fromTile, toTile);
-                        editBuilderContent = $"Tiles have been successfully swapped.";
-                    }
+                    DataWorker.Tiles.Create(Team, toTask, int.Parse(fromTileSelectedTileId[NoTaskName.Length..]));
+                    editBuilderContent = $"{NoTaskName} has been changed to {toTask.Name}.";
                 }
                 else
                 {
-                    editBuilderContent = $"{fromTileSelectPlaceholder} has been changed to {toTask.Name}.";
-                    fromTile.ChangeTask(toTask);
+                    Tile fromTile = DataWorker.Tiles.GetById(int.Parse(fromTileSelectedTileId));
+                    Tile? toTile = DataWorker.Tiles.GetByTeamAndTaskId(Team, toTask.RowId);
+
+                    if (toTile != null)
+                    {
+                        if (toTile == fromTile)
+                        {
+                            editBuilderContent = $"You selected the same tile twice, so nothing happened.";
+                        }
+                        else
+                        {
+                            //DataWorker.Tiles.SwapTasks(fromTile, toTile);
+                            editBuilderContent = $"{fromTile.Task.Name} and {toTask.Name} have been successfully swapped.";
+                        }
+                    }
+                    else
+                    {
+                        //DataWorker.Tiles.ChangeTask(fromTile, toTask);
+                        editBuilderContent = $"{fromTile.Task.Name} has been changed to {toTask.Name}.";
+                    }
                 }
 
                 DataWorker.SaveChanges();

--- a/RSBingoBot/InitialiseTeam.cs
+++ b/RSBingoBot/InitialiseTeam.cs
@@ -70,7 +70,6 @@ namespace RSBingoBot
             {
                 team = dataWorker.Teams.GetByName(Name);
                 BoardChannel = await discordClient.GetChannelAsync(team.BoardChannelId);
-                SetTeamsNoTasks();
             }
             else
             {
@@ -80,20 +79,6 @@ namespace RSBingoBot
             }
 
             RegisterChannelComponentInteractions();
-        }
-
-        private void SetTeamsNoTasks()
-        {
-            AvailableNoTasks[team.RowId] = new();
-            HashSet<int> usedNoTaskIds = team.GetNoTaskTiles().Select(t => t.TaskId).ToHashSet();
-
-            foreach (BingoTask task in dataWorker.BingoTasks.GetAllNoTasks())
-            {
-                if (!usedNoTaskIds.Contains(task.RowId))
-                {
-                    AvailableNoTasks[team.RowId].Add(task);
-                }
-            }
         }
 
         private void CreateTeamEntry()


### PR DESCRIPTION
Cannot currently swap DB Tile tasks without an error.

Commented out the ability to change tiles tasks in the DB for the ChangeTileButtonHandler to wait and hook it up the an update handler class.

Some things may be broken as nothing is Unit tested yet.