### PR TITLE
Refactor/message files

### DIFF
--- a/A/Discord/Entities/Messages/Message.cs
+++ b/A/Discord/Entities/Messages/Message.cs
@@ -11,11 +11,9 @@ using DSharpPlus.Entities;
 
 public class Message : IMessage
 {
-    private Dictionary<string, Stream> streams = new();
+    internal List<MessageFile> FilesInternal { get; set; } = new();
 
-    internal List<(string path, string name)> FilesInternal { get; set; } = new();
-
-    public IReadOnlyList<(string path, string name)> Files => FilesInternal.AsReadOnly();
+    public IReadOnlyList<MessageFile> Files => FilesInternal.AsReadOnly();
 
     public DiscordMessage DiscordMessage { get; private set; }
 
@@ -59,11 +57,7 @@ public class Message : IMessage
     public void OnMessageSent(DiscordMessage discordMessage)
     {
         DiscordMessage = discordMessage;
-
-        foreach (var fs in streams)
-        {
-            fs.Value.Close();
-        }
+        FilesInternal.ForEach(f => f.Close());
     }
 
     /// <summary>
@@ -92,8 +86,8 @@ public class Message : IMessage
 
     private void AddBuilderFiles<T>(T builder) where T : IDiscordMessageBuilder
     {
-        streams = new();
-        FilesInternal.ForEach(f => streams.Add(f.name, new FileStream(f.path, FileMode.Open)));
+        Dictionary<string, Stream> streams = new();
+        FilesInternal.ForEach(f => streams.Add(f.Name, f.Open()));
         builder.AddFiles(streams);
     }
 

--- a/A/Discord/Entities/Messages/Message.cs
+++ b/A/Discord/Entities/Messages/Message.cs
@@ -87,7 +87,14 @@ public class Message : IMessage
     private void AddBuilderFiles<T>(T builder) where T : IDiscordMessageBuilder
     {
         Dictionary<string, Stream> streams = new();
-        FilesInternal.ForEach(f => streams.Add(f.Name, f.Open()));
+        foreach (MessageFile file in FilesInternal)
+        {
+            if (file.HasContent)
+            {
+                streams.Add(file.DiscordName, file.Open());
+            }
+        }
+
         builder.AddFiles(streams);
     }
 

--- a/A/Discord/Entities/Messages/MessageExtensions.cs
+++ b/A/Discord/Entities/Messages/MessageExtensions.cs
@@ -11,7 +11,6 @@ using DiscordLibrary.Factories;
 using DSharpPlus.Entities;
 using RSBingo_Common;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Png;
 
 public static class MessageExtensions
 {
@@ -87,10 +86,10 @@ public static class MessageExtensions
         return AddComponentsCommon(message, components);
     }
 
-    public static T AddFile<T>(this T message, string path, string? name = null)
+    public static T AddFile<T>(this T message, MessageFile file)
         where T : Message
     {
-        message.FilesInternal.Add((path, name ?? NullFileName));
+        message.FilesInternal.Add(file);
         return message;
     }
 
@@ -98,15 +97,6 @@ public static class MessageExtensions
         where T : Message
     {
         message.FilesInternal.Clear();
-        return message;
-    }
-
-    public static T AddImage<T>(this T message, Image image, string? name = null)
-        where T : Message
-    {
-        string path = Path.GetTempFileName();
-        image.Save(path, new PngEncoder());
-        AddFile(message, path, name);
         return message;
     }
 

--- a/A/Discord/Entities/Messages/MessageFile.cs
+++ b/A/Discord/Entities/Messages/MessageFile.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="MessageFile.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+using SixLabors.ImageSharp;
+
+namespace DiscordLibrary.DiscordEntities;
+
+public class MessageFile
+{
+    private FileStream stream = null!;
+
+    public string Name { get; set; }
+    public string Path { get; private set; } = string.Empty;
+
+    public MessageFile(string name = "File")
+    {
+        Name = name;
+        Path = System.IO.Path.GetTempFileName();
+    }
+
+    public void SetContents(Image image, string extension, string name)
+    {
+        Path = System.IO.Path.ChangeExtension(Path, extension);
+        image.Save(Path);
+    }
+
+    public void SetContents(string path)
+    {
+        Path = path;
+    }
+
+    /// <summary>
+    /// Sets <see cref="Name"/> to be the file name at <see cref="Path"/>.
+    /// </summary>
+    public void SetNameFromPath()
+    {
+        Name = System.IO.Path.GetFileName(Path);
+    }
+
+    public FileStream Open()
+    {
+        if (string.IsNullOrEmpty(Path))
+        {
+            throw new InvalidOperationException("Must set file contents before opening it.");
+        }
+
+        stream = new(Path, FileMode.Open, FileAccess.ReadWrite);
+        return stream;
+    }
+
+    public void Close()
+    {
+        stream.Close();
+    }
+}

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesButton/ChangeTilesButtonHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesButton/ChangeTilesButtonHandler.cs
@@ -15,6 +15,7 @@ using DSharpPlus;
 using RSBingo_Framework.DAL;
 using RSBingo_Framework.Interfaces;
 using RSBingo_Framework.Models;
+using RSBingoBot.Discord;
 
 internal class ChangeTilesButtonHandler : ButtonHandler<ChangeTilesButtonRequest>
 {
@@ -43,6 +44,9 @@ internal class ChangeTilesButtonHandler : ButtonHandler<ChangeTilesButtonRequest
 
         user = Interaction.User.GetDBUser(dataWorker)!;
 
+        // TODO: JR - put in a better place, probably store the MessageFile on the DiscordTeam.
+        MessageFile board = DiscordTeam.ExistingTeams[user.Team.Name].BoardMessage!.Files.ElementAt(0);
+
         var response = new InteractionMessage(Interaction)
             .WithContent(GetResponseContent(request));
 
@@ -54,7 +58,7 @@ internal class ChangeTilesButtonHandler : ButtonHandler<ChangeTilesButtonRequest
         Button changeFromBack = buttonFactory.CreateSelectComponentBackButton(() => new(tileSelect.SelectComponent));
         Button changeToBack = buttonFactory.CreateSelectComponentBackButton(() => new(taskSelect.SelectComponent));
         Button apply = buttonFactory.Create(new(ButtonStyle.Primary, "Apply"),
-            () => new ChangeTilesSubmitButtonRequest(dataWorker, user.Team, dto, Interaction.User, tileSelect, taskSelect));
+            () => new ChangeTilesSubmitButtonRequest(dataWorker, user.Team, dto, Interaction.User, tileSelect, taskSelect, board));
         Button close = buttonFactory.CreateConcludeInteraction(() => new(InteractionTracker, new List<Message>() { response }));
 
         response.AddComponents(tileSelect.SelectComponent)

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesSubmitButton/ChangeTilesSubmitButtonHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesSubmitButton/ChangeTilesSubmitButtonHandler.cs
@@ -30,7 +30,6 @@ internal class ChangeTilesSubmitButtonHandler : ButtonHandler<ChangeTilesSubmitB
         Image board = BoardImage.UpdateTiles(request.Team, updatedTiles);
         BoardImage.SaveBoard(board, request.Team.Name);
 
-
         await messageServices.Update(DiscordTeam.ExistingTeams[request.Team.Name].BoardMessage!);
         await messageServices.Update(request.ChangeTilesTileSelect.SelectComponent.Message!);
     }

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesSubmitButton/ChangeTilesSubmitButtonHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesSubmitButton/ChangeTilesSubmitButtonHandler.cs
@@ -28,7 +28,8 @@ internal class ChangeTilesSubmitButtonHandler : ButtonHandler<ChangeTilesSubmitB
         request.ChangeTilesTaskSelect.Update(updatedTiles.Where(t => t.Item1 is not null).Select(t => t.Item1!));
 
         Image board = BoardImage.UpdateTiles(request.Team, updatedTiles);
-        BoardImage.SaveBoard(board, request.Team.Name);
+        var path = BoardImage.SaveBoard(board, request.Team.Name);
+        request.BoardMessageFile.SetContent(path);
 
         await messageServices.Update(DiscordTeam.ExistingTeams[request.Team.Name].BoardMessage!);
         await messageServices.Update(request.ChangeTilesTileSelect.SelectComponent.Message!);

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesSubmitButton/ChangeTilesSubmitButtonRequest.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/ChangeTiles/ChangeTilesSubmitButton/ChangeTilesSubmitButtonRequest.cs
@@ -4,10 +4,12 @@
 
 namespace RSBingoBot.Requests;
 
+using DiscordLibrary.DiscordEntities;
 using DiscordLibrary.Requests;
 using DSharpPlus.Entities;
 using RSBingo_Framework.Interfaces;
 using RSBingo_Framework.Models;
 
 public record ChangeTilesSubmitButtonRequest(IDataWorker DataWorker, Team Team, ChangeTilesButtonDTO DTO, DiscordUser User,
-    ChangeTilesTileSelect ChangeTilesTileSelect, ChangeTilesTaskSelect ChangeTilesTaskSelect) : IButtonRequest;
+    ChangeTilesTileSelect ChangeTilesTileSelect, ChangeTilesTaskSelect ChangeTilesTaskSelect,
+    MessageFile BoardMessageFile) : IButtonRequest;

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitDropMessage/SubmitEvidenceMessageHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitDropMessage/SubmitEvidenceMessageHandler.cs
@@ -21,10 +21,9 @@ internal class SubmitEvidenceMessageHandler : MessageCreatedHandler<SubmitEviden
         request.DTO.EvidenceUrl = attachment.Url;
 
         string extension = "." + attachment.MediaType.Split("/")[1];
-        string imagePath = await SaveImage(request, attachment, extension);
+        string path = await SaveImage(request, attachment, extension);
 
-        request.DTO.Message.RemoveAllFiles();
-        request.DTO.Message.AddFile(imagePath, $"Evidence{extension}");
+        request.EvidenceFile.SetContent(path);
 
         await messageServices.Delete(message);
         await messageServices.Update(request.DTO.Message);
@@ -34,9 +33,9 @@ internal class SubmitEvidenceMessageHandler : MessageCreatedHandler<SubmitEviden
     {
         var webServices = GetRequestService<IWebServices>();
 
-        string imagePath = Paths.GetUserTempEvidencePath(request.User.Id, extension);
-        await webServices.DownloadFile(request.DTO.EvidenceUrl!, imagePath);
+        string path = Paths.GetUserTempEvidencePath(request.User.Id, extension);
+        await webServices.DownloadFile(request.DTO.EvidenceUrl!, path);
 
-        return imagePath;
+        return path;
     }
 }

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitDropMessage/SubmitEvidenceMessageRequest.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitDropMessage/SubmitEvidenceMessageRequest.cs
@@ -8,5 +8,5 @@ using DiscordLibrary.DiscordEntities;
 using DiscordLibrary.Requests;
 using DSharpPlus.Entities;
 
-public record SubmitEvidenceMessageRequest(SubmitEvidenceButtonDTO DTO, DiscordUser User, InteractionMessage ResponseOverride) :
-    IMessageCreatedRequest, IInteractionResponseOverride;
+public record SubmitEvidenceMessageRequest(SubmitEvidenceButtonDTO DTO, DiscordUser User, MessageFile EvidenceFile,
+    InteractionMessage ResponseOverride) : IMessageCreatedRequest, IInteractionResponseOverride;

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitEvidenceButton/SubmitEvidenceButtonHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitEvidenceButton/SubmitEvidenceButtonHandler.cs
@@ -49,8 +49,11 @@ internal class SubmitEvidenceButtonHandler : ButtonHandler<SubmitEvidenceButtonR
         user = Interaction.User.GetDBUser(dataWorker)!;
         evidenceType = request.EvidenceType;
 
+        MessageFile evidenceFile = new("Evidence");
+
         var response = new InteractionMessage(Interaction)
              .WithContent(GetResponsePrefix(Interaction.User))
+             .AddFile(evidenceFile)
              .AsEphemeral(true);
 
         SubmitEvidenceButtonDTO dto = new(response);
@@ -64,7 +67,7 @@ internal class SubmitEvidenceButtonHandler : ButtonHandler<SubmitEvidenceButtonR
         response.AddComponents(submit, cancel);
 
         messageServices.RegisterMessageCreatedHandler(
-            () => new SubmitEvidenceMessageRequest(dto, Interaction.User, new InteractionMessage(Interaction).AsEphemeral(true)),
+            () => new SubmitEvidenceMessageRequest(dto, Interaction.User, evidenceFile, new InteractionMessage(Interaction).AsEphemeral(true)),
             new(Interaction.Channel, Interaction.User, 1));
 
         await interactionMessageServices.Send(response);

--- a/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitEvidenceSubmitButton/SubmitEvidenceSubmitButtonHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Board message buttons/SubmitEvidence/SubmitEvidenceSubmitButton/SubmitEvidenceSubmitButtonHandler.cs
@@ -87,7 +87,7 @@ internal class SubmitEvidenceSubmitButtonHandler : ButtonHandler<SubmitEvidenceS
         var file = request.DTO.Message.Files.ElementAt(0);
         var pendingReviewMessage = new Message(DataFactory.PendingReviewEvidenceChannel)
             .WithContent(GetPendingReviewMessageContent(request, tile))
-            .AddFile(file.path, file.name);
+            .AddFile(file);
 
         // TODO: JR - move the singleton channels to a DTO to use as a singleton with DI.
         Result result = await messageServices.Send(pendingReviewMessage);

--- a/RSBingoBot/Requests/Discord team/Entities/Entities (channels, role etc.)/Messages/AddTeamBoardToMessage/AddTeamBoardToMessageHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Entities (channels, role etc.)/Messages/AddTeamBoardToMessage/AddTeamBoardToMessageHandler.cs
@@ -15,8 +15,11 @@ internal class AddTeamBoardToMessageHandler : RequestHandler<AddTeamBoardToMessa
         try
         {
             Image board = BoardImage.Create(request.Team);
-            string boardPath = BoardImage.SaveBoard(board, request.Team.Name);
-            request.Message.AddFile(boardPath);
+
+            MessageFile file = new("Board");
+            file.SetContent(board, ".png");
+
+            request.Message.AddFile(file);
 
             AddSuccess(new AddTeamBoardToMessageSuccess());
         }

--- a/RSBingoBot/Requests/Discord team/Entities/Entities (channels, role etc.)/Messages/AddTeamBoardToMessage/AddTeamBoardToMessageHandler.cs
+++ b/RSBingoBot/Requests/Discord team/Entities/Entities (channels, role etc.)/Messages/AddTeamBoardToMessage/AddTeamBoardToMessageHandler.cs
@@ -15,9 +15,10 @@ internal class AddTeamBoardToMessageHandler : RequestHandler<AddTeamBoardToMessa
         try
         {
             Image board = BoardImage.Create(request.Team);
+            var path = BoardImage.SaveBoard(board, request.Team.Name);
 
             MessageFile file = new("Board");
-            file.SetContent(board, ".png");
+            file.SetContent(path);
 
             request.Message.AddFile(file);
 


### PR DESCRIPTION
Change Message to use MessageFile instead of (string path, string name).

This is much cleaner and easier to use.

It makes updating a file sent to Discord very easy.
Once a MessageFile is sent to Discord, to update it you just need to re set the content. The Message will automatically use the updated content so there's no need to faff about with paths and names externally anymore.